### PR TITLE
Update port number to be an int not a string to pass HA linter

### DIFF
--- a/hamc-server-bedrock/config.yaml
+++ b/hamc-server-bedrock/config.yaml
@@ -7,7 +7,7 @@ arch:
   - amd64
   - aarch64
 ports:
-  19132/udp: "19132"
+  19132/udp: 19132
 ports_description:
   19132/udp: Minecraft Server Port
 options:


### PR DESCRIPTION
The HA Linter in GitHub actions expects a number and not a string.